### PR TITLE
The image effects \System\Image\Effect\ReflectionEffect and \System\I…

### DIFF
--- a/core4/system/image/effect/ReflectionEffect.class.php
+++ b/core4/system/image/effect/ReflectionEffect.class.php
@@ -147,7 +147,7 @@ class ReflectionEffect extends \System\Image\Effect\ImageEffect
         }
 
         /** @var \Imagick */
-        $reflection = $imageData->clone();
+        $reflection = clone $imageData;
         $reflection->flipImage();
 
         $gradient = new \Imagick();

--- a/core4/system/image/effect/ShadowEffect.class.php
+++ b/core4/system/image/effect/ShadowEffect.class.php
@@ -89,13 +89,12 @@ class ShadowEffect extends \System\Image\Effect\ImageEffect
     */
     protected final function executeFilterImagick(\Imagick $imageData)
     {
-        $shadow = $imageData->clone();
+        $shadow = clone $imageData;
         $shadow->setImageBackgroundColor(new \ImagickPixel('black'));
 
         $shadow->shadowImage(80, $this->shadowWidth / 4, 0, 0);
 
         $shadow->compositeImage($imageData, \Imagick::COMPOSITE_OVER, 0, 0);
-
 
         return $shadow;
     }


### PR DESCRIPTION
The image effects \System\Image\Effect\ReflectionEffect and \System\Image\Effect\ShadowEffect were broken if you use Imagick version 3.1.0 or above which was released 3 years ago.
In these effects the function Imagick::clone is used which is deprecated.
"This function has been DEPRECATED as of imagick 3.1.0 in favour of using the clone keyword."